### PR TITLE
Remove "marksman-" prefix when downloading Marksman for Windows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,12 +44,10 @@ impl MarksmanExtension {
         )?;
 
         let (platform, arch) = zed::current_platform();
-        let asset_name = format!(
-            "marksman-{}",
-            match (platform, arch) {
-                (zed::Os::Linux, zed::Architecture::Aarch64) => "linux-arm64",
-                (zed::Os::Linux, zed::Architecture::X8664) => "linux-x64",
-                (zed::Os::Mac, _) => "macos",
+        let asset_name = match (platform, arch) {
+                (zed::Os::Linux, zed::Architecture::Aarch64) => "marksman-linux-arm64",
+                (zed::Os::Linux, zed::Architecture::X8664) => "marksman-linux-x64",
+                (zed::Os::Mac, _) => "marksman-macos",
                 (zed::Os::Windows, _) => "marksman.exe",
                 (unsupported_os, unsupported_arch) => {
                     return Err(format!(


### PR DESCRIPTION
The extension tries to download "marksman-marksman.exe" instead of "marksman.exe" on Windows.

Fixed by removing the formatting and directly assigning the correct asset name for each platform.

Thanks for the convenient extension!  I'm using it on Linux but it failed to download on Windows for me.  I'm 99% sure this is the fix, but...  I've never written any Rust before this and I didn't compile or test locally.   I'd love a release so I can also use Marksman on Windows.

Thanks,
Charles